### PR TITLE
Fix typo

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Devless is a tool for ready-made back-end for development of web or mobile applications. It is fully open source under the permissive Apache v2 license. This means that you can develop your front end without worrying about neither back-end code or the business risk of a propitiatory backend-as-a-service.
+Devless is a tool for ready-made back-end for development of web or mobile applications. It is fully open source under the permissive Apache v2 license. This means that you can develop your front end without worrying about neither back-end code or the business risk of a proprietary backend-as-a-service.
 
 Ready to start building? Head over to [Quick Start](quick-start.md).
 


### PR DESCRIPTION
In the ```Devless is a tool for ready-made back-end for development of web or mobile applications. It is fully open source under the permissive Apache v2 license. This means that you can develop your front end without worrying about neither back-end code or the business risk of a *propitiatory* backend-as-a-service.``` . Changed `propitiatory` to `proprietary`.